### PR TITLE
Change the portal to be the public one

### DIFF
--- a/aiml20/DEMO Setup.md
+++ b/aiml20/DEMO Setup.md
@@ -128,7 +128,7 @@ and run these commands from a browser window.
 ## Open browser pages ready to demo.
 
 * The deployed Tailwind Trader app 
-* https://portal.azure.com (browse to resources)  
+* https://portal.azure.com/?feature.customportal=false#home (browse to resources - note this link shows the public portal, not the preview version for those with access)  
 * https://azure.microsoft.com/en-us/services/cognitive-services/computer-vision/
 * https://customvision.ai
 * https://lutzroeder.github.io/netron/


### PR DESCRIPTION
Changing link to the portal to be to the public version, not the preview version for those with access (e.g. MS employees always get the preview one, not the public version)