### PR TITLE
Fix serverFarmID reference

### DIFF
--- a/aiml50/template/azuredeploy.json
+++ b/aiml50/template/azuredeploy.json
@@ -352,7 +352,7 @@
                     ],
                     "alwaysOn": "[variables('alwaysOn')]"
                 },
-                "serverFarmId": "[concat('/subscriptions/', variables('subscriptionId'),'/resourcegroups/', variables('serverFarmResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('hostingPlanName'))]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
                 "hostingEnvironment": "[variables('hostingEnvironment')]",
                 "clientAffinityEnabled": true
             },

--- a/aiml50/template/azuredeploy.json
+++ b/aiml50/template/azuredeploy.json
@@ -59,7 +59,6 @@
         "hostingPlanName": "[concat(variables('uniqueName'), '-plan')]",
         "serverFarmResourceGroup": "[resourceGroup().name]",
         "alwaysOn": true,
-        "sku": "PremiumV2",
         "skuCode": "P1v2",
         "workerSize": "3",
         "workerSizeId": "3",
@@ -381,7 +380,6 @@
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "Tier": "[variables('sku')]",
                 "Name": "[variables('skuCode')]"
             },
             "kind": "",


### PR DESCRIPTION
I thought it was the sku reference, but it turned out to be the serverFarmId reference.  For some reason it didn't like the manual assembly of the resourceId anymore and I can't recall why I didn't use the resourceId function before.